### PR TITLE
Fix YAML syntax error and merge conflict in package installation

### DIFF
--- a/.github/workflows/build-mros.yml
+++ b/.github/workflows/build-mros.yml
@@ -55,31 +55,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y \\
-          debootstrap \\
-          squashfs-tools \\
-          xorriso \\
-          isolinux \\
-          syslinux-utils \\
-          mtools \\
-          python3 \\
-          python3-gi \\
-          python3-requests \\
-          python3-pil \\
-          curl \\
-        sudo apt-get install -y \
-          debootstrap \
-          squashfs-tools \
-          xorriso \
-          grub-pc-bin \
-          grub-efi-amd64-bin \
-          mtools \
-          python3 \
-          python3-gi \
-          python3-requests \
-          python3-pil \
-          curl \
-          wget
+        sudo apt-get install -y debootstrap squashfs-tools xorriso isolinux syslinux-utils mtools python3 python3-gi python3-requests python3-pil curl wget
     
     - name: Validate mros configuration
       run: |


### PR DESCRIPTION
- Removed duplicate and malformed package installation commands
- Fixed backslash line continuation syntax that was causing 'E: Unable to locate package \' error
- Consolidated to single clean apt-get install command with correct isolinux packages
- Removed conflicting GRUB packages that were causing merge conflicts

This resolves the apt package installation error in GitHub Actions.