### PR TITLE
Fix ISO file location mismatch between build script and workflow

### DIFF
--- a/.github/workflows/build-mros.yml
+++ b/.github/workflows/build-mros.yml
@@ -136,7 +136,7 @@ jobs:
         sudo -E ./scripts/build-mros.sh
         
         # Check if ISO was created
-        iso_file=$(find /tmp/mros-build -name "*.iso" | head -1)
+        iso_file=$(find /tmp/mros-build /home/runner/mros-build -name "*.iso" 2>/dev/null | head -1)
         if [[ -n "$iso_file" && -f "$iso_file" ]]; then
           echo "ISO created successfully: $iso_file"
           echo "ISO_PATH=$iso_file" >> $GITHUB_ENV

--- a/scripts/build-mros.sh
+++ b/scripts/build-mros.sh
@@ -10,7 +10,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG_FILE="$PROJECT_DIR/mros-config/distribution.conf"
 
 # Default values
-WORK_DIR="$HOME/mros-build"
+WORK_DIR="${WORK_DIR:-$HOME/mros-build}"
 CHROOT_DIR="$WORK_DIR/chroot"
 IMAGE_DIR="$WORK_DIR/image"
 SCRATCH_DIR="$WORK_DIR/scratch"


### PR DESCRIPTION
- Updated build script to respect WORK_DIR environment variable with fallback to default
- Modified workflow to search for ISO in both /tmp/mros-build and /home/runner/mros-build
- This resolves the 'Error: ISO file not found' issue where ISO was created successfully but workflow couldn't find it

The build script was using /root/mros-build (/home/runner/mros-build) while the workflow was looking in /tmp/mros-build.